### PR TITLE
SDK-1488: Allow pem to be provided as a Buffer

### DIFF
--- a/src/profile/client.builder.js
+++ b/src/profile/client.builder.js
@@ -16,12 +16,12 @@ class SandboxProfileClientBuilder {
   }
 
   /**
-   * @param {string} pemString
+   * @param {string|Buffer} pemString
    *
    * @returns {SandboxProfileClientBuilder}
    */
   withPemString(pem) {
-    Validation.isString(pem, 'pem');
+    Validation.notNullOrEmpty(pem, 'pem');
     this.pem = pem;
     return this;
   }

--- a/src/profile/client.js
+++ b/src/profile/client.js
@@ -14,7 +14,7 @@ const SANDBOX_API_URL = `${constants.API_BASE_URL}/sandbox/v1`;
 class SandboxProfileClient {
   /**
    * @param {string} sdkId
-   * @param {string} pem
+   * @param {string|Buffer} pem
    * @param {string} sandboxUrl
    */
   constructor(sdkId, pem, sandboxUrl) {
@@ -22,7 +22,7 @@ class SandboxProfileClient {
     this.sdkId = sdkId;
     this.endpoint = `/apps/${sdkId}/tokens`;
 
-    Validation.isString(pem, 'pem');
+    Validation.notNullOrEmpty(pem, 'pem');
     this.pem = pem;
 
     if (sandboxUrl) {

--- a/tests/profile/client.spec.js
+++ b/tests/profile/client.spec.js
@@ -9,6 +9,7 @@ const SOME_SANDBOX_URL = 'https://somesandbox.yoti.com/api/v1';
 const SOME_ENDPOINT_PATTERN = new RegExp(`^/sandbox/v1/apps/${SOME_SDK_ID}/tokens`);
 const SOME_PEM_FILE_PATH = './tests/sample-data/keys/test.pem';
 const SOME_PEM_STRING = fs.readFileSync(SOME_PEM_FILE_PATH, 'utf8');
+const SOME_PEM_BUFFER = Buffer.from(SOME_PEM_STRING);
 const SOME_TOKEN_REQUEST = new TokenRequestBuilder().build();
 const SOME_TOKEN = 'someToken';
 
@@ -17,6 +18,13 @@ describe('SandboxClient', () => {
     const sandboxClient = new SandboxProfileClientBuilder()
       .withClientSdkId(SOME_SDK_ID)
       .withPemString(SOME_PEM_STRING)
+      .build();
+    expect(sandboxClient).toBeInstanceOf(SandboxClient);
+  });
+  it('should build with pem buffer', () => {
+    const sandboxClient = new SandboxProfileClientBuilder()
+      .withClientSdkId(SOME_SDK_ID)
+      .withPemString(SOME_PEM_BUFFER)
       .build();
     expect(sandboxClient).toBeInstanceOf(SandboxClient);
   });
@@ -42,7 +50,7 @@ describe('SandboxClient', () => {
     });
     it('should throw for missing key', () => {
       expect(() => new SandboxProfileClientBuilder().withClientSdkId(SOME_SDK_ID).build())
-        .toThrow(new TypeError('pem must be a string'));
+        .toThrow(new TypeError('pem cannot be null or empty'));
     });
   });
   describe('#setupSharingProfile', () => {


### PR DESCRIPTION
### Changed
- Allow pem to be provided as a Buffer or string

> Note: Allowing Buffer to be consistent with other SDK clients
