### PR TITLE
SDK-1579: DocScanSandboxError message

### DIFF
--- a/src/doc_scan/doc.scan.sandbox.error.js
+++ b/src/doc_scan/doc.scan.sandbox.error.js
@@ -17,13 +17,12 @@ function errorMessage(error) {
         .response
         .body
         .errors
-        .map((e) => {
-          if (e.property && e.message) {
-            return `${e.property} "${e.message}"`;
+        .reduce((acc, current) => {
+          if (current.property && current.message) {
+            acc.push(`${current.property} "${current.message}"`);
           }
-          return null;
-        })
-        .filter(e => e !== null);
+          return acc;
+        }, []);
 
       if (propertyErrors.length > 0) {
         return `${message}: ${propertyErrors.join(', ')}`;

--- a/src/doc_scan/doc.scan.sandbox.error.js
+++ b/src/doc_scan/doc.scan.sandbox.error.js
@@ -1,14 +1,72 @@
-const DocScanError = require('yoti/src/doc_scan_service/doc.scan.error');
+'use strict';
+
+/**
+ * @param {Error} error
+ */
+function errorMessage(error) {
+  if (
+    error.response
+    && error.response.body
+    && error.response.body.code
+    && error.response.body.message
+  ) {
+    const message = `${error.response.body.code} - ${error.response.body.message}`;
+
+    if (error.response.body.errors) {
+      const propertyErrors = error
+        .response
+        .body
+        .errors
+        .map((e) => {
+          if (e.property && e.message) {
+            return `${e.property} "${e.message}"`;
+          }
+          return null;
+        })
+        .filter(e => e !== null);
+
+      if (propertyErrors.length > 0) {
+        return `${message}: ${propertyErrors.join(', ')}`;
+      }
+    }
+
+    return message;
+  }
+
+  return error.message;
+}
 
 /**
  * Signals that a problem occurred in a Yoti Doc Scan Sandbox
  *
  * @class DocScanSandboxError
  */
-class DocScanSandboxError extends DocScanError {
+class DocScanSandboxError extends Error {
   constructor(error) {
-    super(error);
+    super(errorMessage(error));
+
     this.name = this.constructor.name;
+    this.response = error.response || null;
+  }
+
+  /**
+   * @returns {int}
+   */
+  getResponseStatusCode() {
+    if (this.response && this.response.statusCode) {
+      return this.response.statusCode;
+    }
+    return null;
+  }
+
+  /**
+   * @returns {*} The parsed response body.
+   */
+  getResponseBody() {
+    if (this.response && this.response.body) {
+      return this.response.body;
+    }
+    return null;
   }
 }
 

--- a/tests/doc_scan/doc.scan.sandbox.error.spec.js
+++ b/tests/doc_scan/doc.scan.sandbox.error.spec.js
@@ -9,7 +9,7 @@ const SOME_RESPONSE = {
 };
 
 const SOME_PROPERTY = 'some.property';
-const SOME_PROPERTY_MESSAGE = 'some.property';
+const SOME_PROPERTY_MESSAGE = 'some property message';
 const SOME_OTHER_PROPERTY = 'some.other.property';
 const SOME_OTHER_PROPERTY_MESSAGE = 'some other property message';
 

--- a/tests/doc_scan/doc.scan.sandbox.error.spec.js
+++ b/tests/doc_scan/doc.scan.sandbox.error.spec.js
@@ -1,0 +1,181 @@
+const DocScanSandboxError = require('../../src/doc_scan/doc.scan.sandbox.error');
+
+const SOME_CODE = 'SOME_CODE';
+const SOME_MESSAGE = 'SOME_MESSAGE';
+
+const SOME_RESPONSE = {
+  code: SOME_CODE,
+  message: SOME_MESSAGE,
+};
+
+const SOME_PROPERTY = 'some.property';
+const SOME_PROPERTY_MESSAGE = 'some.property';
+const SOME_OTHER_PROPERTY = 'some.other.property';
+const SOME_OTHER_PROPERTY_MESSAGE = 'some other property message';
+
+const SOME_RESPONSE_WITH_ERRORS = {
+  code: SOME_CODE,
+  message: SOME_MESSAGE,
+  errors: [
+    {
+      property: SOME_PROPERTY,
+      message: SOME_PROPERTY_MESSAGE,
+    },
+    {
+      property: SOME_OTHER_PROPERTY,
+      message: SOME_OTHER_PROPERTY_MESSAGE,
+    },
+  ],
+};
+
+const SOME_RESPONSE_WITH_UNKNOWN_ERRORS = {
+  code: SOME_CODE,
+  message: SOME_MESSAGE,
+  errors: [
+    {
+      some: 'unknown error',
+    },
+  ],
+};
+
+describe('DocScanSandboxError', () => {
+  let docScanError;
+
+  describe('when error has response', () => {
+    beforeEach(() => {
+      const someError = new Error('some error message');
+
+      someError.response = {
+        statusCode: 400,
+        body: SOME_RESPONSE,
+        text: JSON.stringify(SOME_RESPONSE),
+      };
+
+      docScanError = new DocScanSandboxError(someError);
+    });
+
+    it('should be instance of Error', () => {
+      expect(docScanError).toBeInstanceOf(Error);
+    });
+
+    describe('#message', () => {
+      it('should return the error message', () => {
+        expect(docScanError.message).toBe(`${SOME_CODE} - ${SOME_MESSAGE}`);
+      });
+    });
+
+    describe('#name', () => {
+      it('should return the error name', () => {
+        expect(docScanError.name).toBe('DocScanSandboxError');
+      });
+    });
+
+    describe('#getResponseStatusCode', () => {
+      it('should return the status code', () => {
+        expect(docScanError.getResponseStatusCode()).toBe(400);
+      });
+    });
+
+    describe('#getResponseBody', () => {
+      it('should return the response body', () => {
+        expect(docScanError.getResponseBody()).toBe(SOME_RESPONSE);
+      });
+    });
+  });
+  describe('when error has response with errors', () => {
+    beforeEach(() => {
+      const someError = new Error('some error message');
+
+      someError.response = {
+        statusCode: 400,
+        body: SOME_RESPONSE_WITH_ERRORS,
+        text: JSON.stringify(SOME_RESPONSE_WITH_ERRORS),
+      };
+
+      docScanError = new DocScanSandboxError(someError);
+    });
+
+    it('should be instance of Error', () => {
+      expect(docScanError).toBeInstanceOf(Error);
+    });
+
+    describe('#message', () => {
+      it('should return the error message', () => {
+        expect(docScanError.message)
+          .toBe(`${SOME_CODE} - ${SOME_MESSAGE}: ${SOME_PROPERTY} "${SOME_PROPERTY_MESSAGE}", ${SOME_OTHER_PROPERTY} "${SOME_OTHER_PROPERTY_MESSAGE}"`);
+      });
+    });
+
+    describe('#name', () => {
+      it('should return the error name', () => {
+        expect(docScanError.name).toBe('DocScanSandboxError');
+      });
+    });
+
+    describe('#getResponseStatusCode', () => {
+      it('should return the status code', () => {
+        expect(docScanError.getResponseStatusCode()).toBe(400);
+      });
+    });
+
+    describe('#getResponseBody', () => {
+      it('should return the response body', () => {
+        expect(docScanError.getResponseBody()).toBe(SOME_RESPONSE_WITH_ERRORS);
+      });
+    });
+  });
+  describe('when error has response with unknown errors', () => {
+    beforeEach(() => {
+      const someError = new Error('some error message');
+
+      someError.response = {
+        statusCode: 400,
+        body: SOME_RESPONSE_WITH_UNKNOWN_ERRORS,
+        text: JSON.stringify(SOME_RESPONSE_WITH_UNKNOWN_ERRORS),
+      };
+
+      docScanError = new DocScanSandboxError(someError);
+    });
+
+    describe('#message', () => {
+      it('should exclude unknown errors', () => {
+        expect(docScanError.message)
+          .toBe(`${SOME_CODE} - ${SOME_MESSAGE}`);
+      });
+    });
+  });
+  describe('when error has no response', () => {
+    beforeEach(() => {
+      const someError = new Error('some error message');
+      docScanError = new DocScanSandboxError(someError);
+    });
+
+    it('should be instance of Error', () => {
+      expect(docScanError).toBeInstanceOf(Error);
+    });
+
+    describe('#message', () => {
+      it('should return the error message', () => {
+        expect(docScanError.message).toBe('some error message');
+      });
+    });
+
+    describe('#name', () => {
+      it('should return the error name', () => {
+        expect(docScanError.name).toBe('DocScanSandboxError');
+      });
+    });
+
+    describe('#getResponseStatusCode', () => {
+      it('should return null', () => {
+        expect(docScanError.getResponseStatusCode()).toBeNull();
+      });
+    });
+
+    describe('#getResponseBody', () => {
+      it('should return null', () => {
+        expect(docScanError.getResponseBody()).toBeNull();
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Changed
- API error message is now included in `DocScanSandboxError` message. Falls back on the message of the error it is wrapping (e.g. "Bad Request")

### Fixed
- `DocScanSandboxError` no longer extends `DocScanError` as they represent errors for separate services

#### Notes:
- Follows same format as https://github.com/getyoti/yoti-node-sdk/pull/189 - the message formatting function has been copied to avoid an unnecessary dependency between projects.
