### PR TITLE
SDK-1665: Update example for base64 URL token

### DIFF
--- a/examples/profile/profile.spec.js
+++ b/examples/profile/profile.spec.js
@@ -137,8 +137,8 @@ describe('Sandbox Example', () => {
       .toEqual('YOTI_ADMIN');
 
     const attributeIssuanceDetails = activityDetails.getExtraData().getAttributeIssuanceDetails();
-    expect(attributeIssuanceDetails.getToken())
-      .toEqual(Buffer.from('some-token').toString('base64'));
+    expect(Buffer.from(attributeIssuanceDetails.getToken(), 'base64').toString())
+      .toEqual('some-token');
     expect(attributeIssuanceDetails.getExpiryDate().getTime())
       .toEqual(expiryDate.getTime());
     expect(attributeIssuanceDetails.getIssuingAttributes()[0].getName())


### PR DESCRIPTION
> No release required (example only)

### Changed
- Update example for base64 URL token


_Note: Node handles decoding of URL and non-URL base64, but not encoding, so the example has been updated to decode the token and compare to the original unencoded value to work in all cases_